### PR TITLE
Change table title to 12px/1.2rem in block starting in line 208

### DIFF
--- a/css/article-content.less
+++ b/css/article-content.less
@@ -209,6 +209,7 @@
   color: #00a2e3;
   font-style: normal;
   font-family: "OpenSans", Helvetica, Arial, sans-serif;
+  font-size: 12px; font-size: 1.2rem;
 }
 
 /* Ordered Lists */


### PR DESCRIPTION
Proposed fix to mulesoft-docs-site-assets/edit/master/css/article-content.less

Change from (line 208):

.article-content table.tableblock>.title {
 color: #00a2e3 ;
 font-style: normal;
 font-family: "OpenSans", Helvetica, Arial, sans-serif;

To:

.article-content table.tableblock>.title {
 color: #00a2e3 ;
 font-style: normal;
 font-family: "OpenSans", Helvetica, Arial, sans-serif;
​ font-size: 12px; font-size: 1.2rem;
