### PR TITLE
Update article-content.less

### DIFF
--- a/css/article-content.less
+++ b/css/article-content.less
@@ -540,7 +540,7 @@
   font-size: 30px;
   position: absolute;
   left: -14.5px;
-  top: -5px;
+  top: 0px;
 }
 
 


### PR DESCRIPTION
Changing top value from:

```css
.article-content ol li p:before{
  content:'.';
  color: #f9f9f9;
  font-size: 30px;
  position: absolute;
  left: -14.5px;
  top: -5px;
}
```
to

```css
  top: 0px;
```

Changing this style This might fix the issue we are having regarding list numbers not fully showing in our docs site.