### PR TITLE
fix mobile layout

### DIFF
--- a/_templates/default.template
+++ b/_templates/default.template
@@ -111,13 +111,13 @@
 
 <div class="container">
     <div class="row sub-header" data-swiftype-index='false'>
-      <div class="search-box col-md-3 col-xs-8">
+      <div class="search-box col-md-3 col-xs-6">
           <form action="">
               <i class="glyphicon glyphicon-search"></i><input class="search-field st-ui-search-input st-default-search-input" type="text" name="search-docs" placeholder="Search the docs">
               <input type="submit" value="Submit">
           </form>
       </div>
-      <div class="toolbar col-md-5 col-xs-4">
+      <div class="toolbar col-md-5 col-xs-6">
           <div class="toolbar-dropdown show-hide-sidebar">
               <a href="#" class="tree-icon glyphicon glyphicon-th-list"><span>Nav</span></a>
           </div>

--- a/css/sub-header.less
+++ b/css/sub-header.less
@@ -1,9 +1,5 @@
 @import "variables.less";
 
-.container.sub-header-fixed {
-  margin-top: 70px;
-}
-
 .sub-header {
     font-family: "OpenSans", Helvetica, Arial, sans-serif;
 
@@ -329,8 +325,20 @@
 
 }
 
+.container.sub-header-fixed {
+  margin-top: 70px;
+}
+
 @media (max-width: 992px) {
+  .container.sub-header-fixed {
+    margin-top: 140px;
+  }
+
   .sub-header {
+    .show-hide-sidebar a.tree-icon:before {
+      background-image: url('../img/nav-menu.svg') !important;
+      margin-top: 0 !important;
+    }
 
     .search-box{
       .search-field {
@@ -338,9 +346,6 @@
         &:hover {
           border-bottom: 0px;
         }
-      }
-      a > .tree-icon{
-        margin-top:0;
       }
       &.fullwidth{
         width:100%;
@@ -355,7 +360,9 @@
       .toolbar-dropdown{
 
         .btn {
-          padding: 2px;
+          padding: 5px 0;
+          margin-left: 0;
+          margin-right: 0;
           font-size: 13px !important;
           span {
             font-size: 13px !important;

--- a/img/nav-menu.svg
+++ b/img/nav-menu.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" enable-background="new 0 0 160 160" viewBox="0 0 160 160" y="0px" x="0px" version="1.1">
+    <g>
+        <rect fill="none" height="160" width="160" x="0"/>
+        <g>
+            <rect fill="none" height="160" width="160" x="0"/>
+            <rect style="fill:#000000" transform="matrix(0,1,-1,0,0,0)" height="101.7" width="20" y="-130.85001" x="69.137009"/>
+            <rect transform="matrix(0,1,-1,0,0,0)" height="101.7" width="20" y="-130.85001" x="28.273544" style="fill:#000000"/>
+            <rect transform="matrix(0,1,-1,0,0,0)" height="101.7" width="20" y="-130.85001" x="110.00047" style="fill:#000000"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
- close sidebar menu when loading or resizing on small screen
- set content offset to account for pinned toolbar height on mobile
- use hamburger icon for sidebar menu toggle on mobile
- max search box smaller on mobile
- don't hide version toggle on mobile
- don't squish content in sidebar menu when closing
- don't overflow width when expanding sidebar menu
- place active marker after expanding sidebar menu