### PR TITLE
use affix plugin to manage position of sub-header

### DIFF
--- a/css/scroll-menu.less
+++ b/css/scroll-menu.less
@@ -3,15 +3,13 @@
 .scroll-menu-container {
   padding: 0;
   .scroll-menu {
-    //margin: 53px 0 20px 0;
-    margin: 53px 0;
+    //margin: 53px 0;
+    margin: 53px 0 20px 0;
     padding-left: 20px;
-    position: relative;
     top: 0;
     width: 170px;
     overflow-y: auto;
     &.affix {
-      position: fixed;
       top: @mulesoft-toolbar-height; // must match height of .sub-header
     }
     h4 {

--- a/css/styles.less
+++ b/css/styles.less
@@ -99,6 +99,10 @@ a:focus {
   background: url('../img/fancybox_overlay.png');
 }
 
+.affix-bottom {
+  position: absolute;
+}
+
 @media (min-width: 768px) {
   .container {
     width: auto;

--- a/css/sub-header.less
+++ b/css/sub-header.less
@@ -166,19 +166,19 @@
           padding-top: 69px;
         }
         i.star, i.star-empty {
-          background: url('../img/blue-star.svg') left center no-repeat;
+          background: left center no-repeat;
           width: 15px;
           height: 15px;
           display: inline-block;
           cursor: pointer;
         }
+        i.star, i.star-empty:hover {
+          background-image: url('../img/blue-star.svg');
+          opacity: 1;
+        }
         i.star-empty {
           background-image: url('../img/black-star.svg');
           opacity: 0.5;
-          &:hover {
-            background-image: url('../img/blue-star.svg');
-            opacity: 1;
-          }
         }
         li {
           margin-bottom: 0;
@@ -343,16 +343,14 @@
   }
 }
 
-.container.sub-header-fixed {
+// NOTE setting margin-top on .row is smoother than setting it on .container
+.affixed-sub-header .sub-header + .row {
   margin-top: @mulesoft-toolbar-height;
-  .sub-header {
-    position: fixed;
-  }
 }
 
 @media (max-width: 992px) {
-  .container.sub-header-fixed {
-    margin-top: 140px;
+  .affixed-sub-header .sub-header + .row {
+    margin-top: @mulesoft-toolbar-height * 2;
   }
 
   .sub-header {


### PR DESCRIPTION
- use affix plugin to manage sub-header position
- update styles to make transition to fixed sub-header smoother
- add global style for position of affix-bottom
- don't highlight first item in content toc by default
- consolidate some styles
- minor code cleanups
