### PR TITLE
don't affix site nav if article is shorter than viewport

### DIFF
--- a/css/sidebar-menu.less
+++ b/css/sidebar-menu.less
@@ -95,9 +95,10 @@
     // NOTE override any width and max-height values set by JavaScript; technically not necessary
     width: auto !important;
     max-height: initial !important;
-    &.affix, &.affix-bottom {
+    &.affix-top, &.affix, &.affix-bottom {
+      //position: relative;
+      //top: 0px;
       position: static;
-      //top: 0;
     }
   }
 }


### PR DESCRIPTION
- veto affix behavior if article content is shorter than viewport
- change article width before calculating dimensions of site nav when opening
- fix timing when affixing site nav
- improve performance