### PR TITLE
reset white-space and word-wrap to default behaviour

### DIFF
--- a/css/article-content.less
+++ b/css/article-content.less
@@ -12,7 +12,6 @@
 .article-content{
   background: white;
   padding: 20px 16px 70px 26px;
-  word-wrap: break-word;
 
   .sect1 {
     border: none;
@@ -183,7 +182,6 @@
   border: none;
   border-bottom: 1px solid #e9e9e9;
   max-width: 200px;
-  word-wrap: break-word;
   font-size: 14px;
 
   strong {
@@ -278,12 +276,8 @@ pre > code {
   }
   .listingblock {
     > .content {
-      pre.CodeRay {
-        white-space: normal;
-        > code {
-          display: block;
-          white-space: normal;
-        }
+      pre.CodeRay > code {
+        display: block;
       }
       > pre:not(.CodeRay) {
         border-left: 4px solid @mulesoft-light-grey;
@@ -315,10 +309,6 @@ pre > code {
           border-right: 4px solid @mulesoft-light-grey;
           padding: 10px 10px 10px 45px;
           width: 100%;
-          > pre {
-            white-space: pre;
-            word-wrap: normal;
-          }
         }
       }
     }
@@ -337,10 +327,6 @@ pre > code {
 }
 
 /* FF Solution  */
-.article-content .admonitionblock td.content,
-.article-content p {
-  word-wrap: break-word;
-}
 .article-content.col-md-7 .admonitionblock td.content,
 .article-content.col-md-7 .admonitionblock .article-content p {
   max-width: 400px;


### PR DESCRIPTION
This will prevent stuffs like these :

The word **Operation** is incorrectly split :

![capture du 2016-07-21 22-04-34](https://cloud.githubusercontent.com/assets/236342/17037055/7da50566-4f8f-11e6-8721-33adf58dc387.png)

The same problem could cause this on small table columns (NOTE : I forced the first column width to generate this screenshot) :

![capture du 2016-07-21 22-06-23](https://cloud.githubusercontent.com/assets/236342/17037072/8cc54a9c-4f8f-11e6-87fe-bfa381d95ab7.png)

Some code samples don't respect line breaks :

![capture du 2016-07-21 22-06-53](https://cloud.githubusercontent.com/assets/236342/17037101/a6baddae-4f8f-11e6-8d37-ab5e59066acb.png)
